### PR TITLE
Corrected a broken ssl link & meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf8">
+    <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="og:image" content="http://anvil.hacksmiths.club/img/og.png">
@@ -26,7 +26,7 @@
         <!-- <li><a target="_blank" href="http://goldsmithssu.org"><img src="img/logo-gssu.png" alt="Goldsmiths SU Logo"></a></li> -->
         <!-- <li><a target="_blank" href="http://www.gold.ac.uk/computing/"><img src="img/logo-goldsmiths.png" alt="Goldsmiths Logo" class="gs"></a></li> -->
         <li><a target="_blank" href="https://twilio.com"><img src="img/logo-twilio.png" alt="Twilio Logo"></a></li>
-        <li><a target="_blank" href="https://indee.io"><img src="img/logo-indee.svg" alt="Indee Logo"></a></li>
+        <li><a target="_blank" href="http://indee.io"><img src="img/logo-indee.svg" alt="Indee Logo"></a></li>
       </ul>
     </div>
     <div class="intro container center">


### PR DESCRIPTION
Meta charset was incorect and also the link to indee is broken because they don't use correct https, at least on chrome as can be seen bellow.

When clicking on https indee link: 

<img width="701" alt="screen shot 2017-03-01 at 22 06 55" src="https://cloud.githubusercontent.com/assets/8436717/23483718/fcadea44-fecb-11e6-8191-67f0048080cb.png">

Best solution would be for indee to fix their SSL cert.

